### PR TITLE
Correctly handle empty buffer.

### DIFF
--- a/test/bqredis_unit_test.py
+++ b/test/bqredis_unit_test.py
@@ -17,39 +17,56 @@ class TestBQRedis(unittest.TestCase):
         )
         self.query_str = "SELECT foo FROM bar;"
         self.query_hash = hashlib.sha256(self.query_str.encode()).hexdigest()
-        self.expected_result = pa.RecordBatch.from_arrays(
-            [pa.array(["ZW", "ZM", "ZA"])], names=["alpha_2_code"]
-        )
-        self.expected_bin_schema = self.expected_result.schema.serialize().to_pybytes()
-        self.expected_bin_data = io.BytesIO(
-            self.expected_result.serialize().to_pybytes()
-        )
-        self.mock_query_result = bqredis._QueryResult(
-            key=self.cache.redis_key_prefix + self.query_hash,
-            serialized_schema=self.expected_bin_schema,
-            serialized_data=self.expected_bin_data,
-        )
-        self.mock_query_result.records = self.expected_result
-        self.bigquery_execution_patcher = unittest.mock.patch.object(
-            self.cache, "_execute_query_to_bytes", return_value=self.mock_query_result
-        )
-        self.execution_mock = self.bigquery_execution_patcher.start()
 
-    def tearDown(self):
-        self.bigquery_execution_patcher.stop()
-        return super().tearDown()
+    def mock_execute_query_to_bytes(
+        self, key: str, expected_result: pa.RecordBatch
+    ) -> unittest.mock.MagicMock:
+        mock_query_result = bqredis._QueryResult(
+            key=key,
+            serialized_schema=expected_result.schema.serialize().to_pybytes(),
+            serialized_data=io.BytesIO(expected_result.serialize().to_pybytes()),
+        )
+        return unittest.mock.patch.object(  # type: ignore
+            self.cache, "_read_bigquery_bytes", return_value=mock_query_result
+        )
 
     def test_execution_called_only_once_with_cache(self):
-        self.assertEqual(self.execution_mock.call_count, 0)
-        result = self.cache.query_sync(self.query_str)
-        self.assertEqual(result, self.expected_result)
-        self.execution_mock.assert_called_once_with(
-            self.query_str, self.cache.redis_key_prefix + self.query_hash
+        key = self.cache.redis_key_prefix + self.query_hash
+        expected_result = pa.RecordBatch.from_arrays(
+            [pa.array(["ZW", "ZM", "ZA"])], names=["alpha_2_code"]
         )
-        self.assertEqual(self.execution_mock.call_count, 1)
-        second_result = self.cache.query_sync(self.query_str)
-        self.assertEqual(second_result, self.expected_result)
-        self.assertEqual(self.execution_mock.call_count, 1)
+        with self.mock_execute_query_to_bytes(key, expected_result) as execution_mock:
+            self.assertEqual(execution_mock.call_count, 0)
+            result = self.cache.query_sync(self.query_str)
+            self.assertEqual(result, expected_result)
+            execution_mock.assert_called_once_with(self.query_str, key)
+            self.assertEqual(execution_mock.call_count, 1)
+            second_result = self.cache.query_sync(self.query_str)
+            self.assertEqual(second_result, expected_result)
+            self.assertEqual(execution_mock.call_count, 1)
+
+    def test_execution_called_only_once_with_cache_empty_result(self):
+        key = self.cache.redis_key_prefix + self.query_hash
+        returned_bytes = bqredis._QueryResult(
+            key=key,
+            serialized_schema=pa.RecordBatch.from_arrays(
+                [pa.array(["ZW", "ZM", "ZA"])], names=["alpha_2_code"]
+            )
+            .schema.serialize()
+            .to_pybytes(),
+            serialized_data=io.BytesIO(b""),
+        )
+        with unittest.mock.patch.object(
+            self.cache, "_read_bigquery_bytes", return_value=returned_bytes
+        ) as execution_mock:
+            self.assertEqual(execution_mock.call_count, 0)
+            result = self.cache.query_sync(self.query_str)
+            self.assertEqual(len(result), 0)
+            execution_mock.assert_called_once_with(self.query_str, key)
+            self.assertEqual(execution_mock.call_count, 1)
+            second_result = self.cache.query_sync(self.query_str)
+            self.assertEqual(len(second_result), 0)
+            self.assertEqual(execution_mock.call_count, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Bigquery sends an empty buffer back for no rows.