### PR TITLE
Store query submission time in redis.

### DIFF
--- a/test/bqredis_unit_test.py
+++ b/test/bqredis_unit_test.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import datetime
 import hashlib
 import io
 import threading
@@ -13,6 +14,7 @@ import bqredis
 def _query_result(key: str, result: pa.RecordBatch) -> bqredis._QueryResult:
     return bqredis._QueryResult(
         key=key,
+        query_time=datetime.datetime.now(datetime.timezone.utc),
         serialized_schema=result.schema.serialize().to_pybytes(),
         serialized_data=io.BytesIO(result.serialize().to_pybytes()),
     )
@@ -50,48 +52,57 @@ class TestBQRedis(unittest.TestCase):
         records = pa.RecordBatch.from_arrays(
             [pa.array(["ZW", "ZM", "ZA"])], names=["alpha_2_code"]
         )
+        mock_result = _query_result(key, records)
         # With no value set, should not find anything
         with unittest.mock.patch.object(self.cache.executor, "submit") as mock_submit:
             self.assertEqual(
-                self.cache._check_redis_cache(self.query_str, key, None), None
+                self.cache._check_redis_cache(self.query_str, key, None), (None, None)
             )
             self.assertEqual(mock_submit.call_count, 0)
             self.assertEqual(
-                self.cache._check_redis_cache(self.query_str, key, 10), None
+                self.cache._check_redis_cache(self.query_str, key, 10), (None, None)
             )
             self.assertEqual(mock_submit.call_count, 0)
             self.assertEqual(
-                self.cache._check_redis_cache(self.query_str, key, 0), None
+                self.cache._check_redis_cache(self.query_str, key, 0), (None, None)
             )
             self.assertEqual(mock_submit.call_count, 0)
         ft = concurrent.futures.Future()
-        ft.set_result(_query_result(key, records))
+        ft.set_result(mock_result)
         self.cache._cache_put(ft)
         with unittest.mock.patch.object(self.cache.executor, "submit") as mock_submit:
             # A fresh result should get returned, with no cache refresh
             self.assertEqual(
-                self.cache._check_redis_cache(self.query_str, key, None), records
+                self.cache._check_redis_cache(self.query_str, key, None),
+                (records, mock_result.query_time),
             )
             self.assertEqual(mock_submit.call_count, 0)
             self.assertEqual(
-                self.cache._check_redis_cache(self.query_str, key, 1), records
+                self.cache._check_redis_cache(self.query_str, key, 1),
+                (records, mock_result.query_time),
             )
             self.assertEqual(mock_submit.call_count, 0)
 
             # Data is close to expiring - only 10 seconds left. Its age is now mocked as 3600 - 10
-            self.cache.redis_client.expire(key + ":data", 10)
+            about_to_expire = datetime.datetime.now(
+                datetime.timezone.utc
+            ) - datetime.timedelta(seconds=3590)
+            self.cache.redis_client.set(
+                key + ":query_time", about_to_expire.isoformat()
+            )
             self.assertEqual(
-                self.cache._check_redis_cache(self.query_str, key, None), records
+                self.cache._check_redis_cache(self.query_str, key, None),
+                (records, about_to_expire),
             )
             self.assertEqual(mock_submit.call_count, 1)
             # Requesting a fresh result does not find anything, and does not schedule a background
             # refresh because the main execution will be used to fill the cache.
             self.assertEqual(
-                self.cache._check_redis_cache(self.query_str, key, 1), None
+                self.cache._check_redis_cache(self.query_str, key, 1), (None, None)
             )
             self.assertEqual(mock_submit.call_count, 1)
             self.assertEqual(
-                self.cache._check_redis_cache(self.query_str, key, 0), None
+                self.cache._check_redis_cache(self.query_str, key, 0), (None, None)
             )
             self.assertEqual(mock_submit.call_count, 1)
 
@@ -103,8 +114,10 @@ class TestBQRedis(unittest.TestCase):
         with self.mock_execute_query_to_bytes() as execution_mock:
             execution_mock.return_value = _query_result(key, expected_result)
             self.assertEqual(execution_mock.call_count, 0)
-            result = self.cache.query_sync(self.query_str)
-            self.assertEqual(result, expected_result)
+            result = self.cache.query_sync_with_time(self.query_str)
+            self.assertEqual(len(result), 2)
+            self.assertEqual(result[0], expected_result)
+            self.assertEqual(result[1], execution_mock.return_value.query_time)
             execution_mock.assert_called_once_with(self.query_str, key)
             self.assertEqual(execution_mock.call_count, 1)
             second_result = self.cache.query_sync(self.query_str)
@@ -113,15 +126,11 @@ class TestBQRedis(unittest.TestCase):
 
     def test_execution_called_only_once_with_cache_empty_result(self):
         key = self.cache.redis_key_prefix + self.query_hash
-        returned_bytes = bqredis._QueryResult(
-            key=key,
-            serialized_schema=pa.RecordBatch.from_arrays(
-                [pa.array(["ZW", "ZM", "ZA"])], names=["alpha_2_code"]
-            )
-            .schema.serialize()
-            .to_pybytes(),
-            serialized_data=io.BytesIO(b""),
+        returned_bytes = _query_result(
+            key, pa.RecordBatch.from_arrays([pa.array([])], names=["alpha_2_code"])
         )
+        # Sometimes, we actually just end up with an empty set of bytes.
+        returned_bytes.serialized_data = io.BytesIO(b"")
         with unittest.mock.patch.object(
             self.cache, "_read_bigquery_bytes", return_value=returned_bytes
         ) as execution_mock:


### PR DESCRIPTION
This makes the expiration calculations simpler and more robust than the previous method, which inferred age from the TTL. Not only was this confusing, but it also would be inaccurate if another instance of bqredis used the same key prefix but a different TTL to store the data.